### PR TITLE
fix(pip): Remove deprecation in installing pip modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,9 +19,7 @@
 
 - name: install needed Python modules
   pip:
-    name: "{{ item }}"
-  with_items:
-    - "{{ needed_python_modules }}"
+    name: "{{ needed_python_modules }}"
 
 - name: install extra needed Python modules
   pip:


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "pip" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: {{ item }}`, please use `name:
[u'{{ needed_python_modules }}']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```