### PR TITLE
feat: Use ansible command module to optionally install python

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: install Python 2
-  raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+  command: apt -y update && apt install -y python-minimal
+  args:
+    creates: /usr/bin/python
 
 - name: install needed packages
   package:


### PR DESCRIPTION
Use ansible command module:
https://docs.ansible.com/ansible/latest/modules/command_module.html
It provides an option `args.creates` which runs task only if file does not yet exist